### PR TITLE
Add missing config/secrets.yml

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'pry'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,7 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.3)
     byebug (10.0.2)
+    coderay (1.1.2)
     concurrent-ruby (1.0.5)
     crass (1.0.4)
     database_cleaner (1.7.0)
@@ -86,6 +87,9 @@ GEM
     nio4r (2.3.1)
     nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
+    pry (0.11.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
     puma (3.12.0)
     rack (2.0.5)
     rack-test (1.1.0)
@@ -171,6 +175,7 @@ DEPENDENCIES
   faker
   jwt
   listen (>= 3.0.5, < 3.2)
+  pry
   puma (~> 3.11)
   rails (~> 5.2.1)
   rspec-rails (~> 3.5)
@@ -184,4 +189,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.16.2
+   1.16.3

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,0 +1,32 @@
+# Be sure to restart your server when you modify this file.
+
+# Your secret key is used for verifying the integrity of signed cookies.
+# If you change this key, all old signed cookies will become invalid!
+
+# Make sure the secret is at least 30 characters and all random,
+# no regular words or you'll be exposed to dictionary attacks.
+# You can use `rails secret` to generate a secure secret key.
+
+# Make sure the secrets in this file are kept private
+# if you're sharing your code publicly.
+
+# Shared secrets are available across all environments.
+
+# shared:
+#   api_key: a1B2c3D4e5F6
+
+# Environmental secrets are only available for that specific environment.
+
+development:
+  secret_key_base: 94e371ded64d7e82baf6739042172bb7fd718e3a0c24e41b5384dcfb8d75f099c5bcc67e06bb40f1f358c346141ab9ac7250cd7c9c89b0fa4537a704ac98b9ab
+
+test:
+  secret_key_base: 4448c54d4e207028fcdb8946e244eafba08dcd649f20bc7d303a251b7747cda090f5eafa50b84f6f13069d54a1ab56121d7500faf35cbb4b12fe918972b26373
+
+# Do not keep production secrets in the unencrypted secrets file.
+# Instead, either read values from the environment.
+# Or, use `bin/rails secrets:setup` to configure encrypted secrets
+# and move the `production:` environment over there.
+
+production:
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>


### PR DESCRIPTION
As of Rails 5.2 Rails secrets usually in config/secrets.yml have been
deprecated in favour of encrypted credentials. [read here](https://weblog.rubyonrails.org/2018/3/20/Rails-5-2-RC2/)

This PR (manually) adds a config/secrets.yml file that houses the
secrets by env that are used in JsonWebToken::HMAC_SECRET
(Rails.application.secrets.secret_key_base)

Please note that on deploy you'll need to set an env var ["SECRET_KEY_BASE"].
You can generate a new secret by running:

```sh
$ rake secret
```

![screen shot 2018-10-11 at 21 24 51](https://user-images.githubusercontent.com/17295175/46826164-f93ec480-cd9d-11e8-8279-1ecabc22e092.jpg)

![screen shot 2018-10-11 at 21 39 24](https://user-images.githubusercontent.com/17295175/46826239-28edcc80-cd9e-11e8-9fb6-f7c795dea14a.jpg)
